### PR TITLE
Set default module path via compile time option

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -31,10 +31,11 @@ vsgi_sources = files(
     'vsgi-server-module.vala',
     'vsgi-server.vala',
     'vsgi-socket-server.vala',
-    'vsgi-tee-output-stream.vala')
+    'vsgi-tee-output-stream.vala',
+    join_paths(meson.current_build_dir(), 'vsgi-config.vala'))
 
 
-vsgi_lib = library('vsgi-' + api_version, vsgi_config, vsgi_sources,
+vsgi_lib = library('vsgi-' + api_version, vsgi_sources,
                    dependencies: [glib, gobject, gio, gio_unix, gmodule, soup, libsystemd, openssl, posix],
                    vala_header: 'vsgi.h',
                    vala_gir: 'VSGI-@0@.gir'.format(api_version),

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,13 +1,17 @@
 conf_data = configuration_data()
-conf_data.set(
-    'MODULE_DIR',
-    join_paths(get_option('prefix'), get_option('libdir'), 'vsgi-@0@/servers'.format(api_version)))
+module_dir = ''
+if get_option('buildtype') == 'debug'
+    module_dir = join_paths(meson.current_build_dir(), 'servers')
+else
+    module_dir = join_paths(get_option('prefix'), get_option('libdir'), 'vsgi-@0@/servers'.format(api_version))
+endif
+
+conf_data.set('MODULE_DIR', module_dir)
 
 vsgi_config = configure_file(
     input: 'vsgi-config.vala.in',
     output: 'vsgi-config.vala',
-    configuration: conf_data
-)
+    configuration: conf_data)
 
 vsgi_sources = files(
     'vsgi.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -38,7 +38,6 @@ vsgi_lib = library('vsgi-' + api_version, vsgi_config, vsgi_sources,
                    dependencies: [glib, gobject, gio, gio_unix, gmodule, soup, libsystemd, openssl, posix],
                    vala_header: 'vsgi.h',
                    vala_gir: 'VSGI-@0@.gir'.format(api_version),
-                   build_rpath: join_paths(meson.current_build_dir(), 'servers'),
                    install: true,
                    install_dir: [true, 'include/vsgi-' + api_version, true, true])
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,14 @@
+conf_data = configuration_data()
+conf_data.set(
+    'MODULE_DIR',
+    join_paths(get_option('prefix'), get_option('libdir'), 'vsgi-@0@/servers'.format(api_version)))
+
+vsgi_config = configure_file(
+    input: 'vsgi-config.vala.in',
+    output: 'vsgi-config.vala',
+    configuration: conf_data
+)
+
 vsgi_sources = files(
     'vsgi.vala',
     'vsgi-application.vala',
@@ -17,15 +28,15 @@ vsgi_sources = files(
     'vsgi-server.vala',
     'vsgi-socket-server.vala',
     'vsgi-tee-output-stream.vala')
-vsgi_lib = library('vsgi-' + api_version, vsgi_sources,
+
+
+vsgi_lib = library('vsgi-' + api_version, vsgi_config, vsgi_sources,
                    dependencies: [glib, gobject, gio, gio_unix, gmodule, soup, libsystemd, openssl, posix],
                    vala_header: 'vsgi.h',
                    vala_gir: 'VSGI-@0@.gir'.format(api_version),
                    build_rpath: join_paths(meson.current_build_dir(), 'servers'),
-                   link_args: ['-Wl,--disable-new-dtags'],
                    install: true,
-                   install_dir: [true, 'include/vsgi-' + api_version, true, true],
-                   install_rpath: join_paths(get_option('prefix'), get_option('libdir'), 'vsgi-@0@/servers'.format(api_version)))
+                   install_dir: [true, 'include/vsgi-' + api_version, true, true])
 
 install_data('vsgi-@0@.deps'.format(api_version),
              install_dir: 'share/vala/vapi')

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,10 +7,10 @@ else
 endif
 
 conf_data.set('MODULE_DIR', module_dir)
-
+vsgi_config_name = 'vsgi-config.vala'
 vsgi_config = configure_file(
-    input: 'vsgi-config.vala.in',
-    output: 'vsgi-config.vala',
+    input: vsgi_config_name + '.in',
+    output: vsgi_config_name,
     configuration: conf_data)
 
 vsgi_sources = files(
@@ -32,7 +32,7 @@ vsgi_sources = files(
     'vsgi-server.vala',
     'vsgi-socket-server.vala',
     'vsgi-tee-output-stream.vala',
-    join_paths(meson.current_build_dir(), 'vsgi-config.vala'))
+    join_paths(meson.current_build_dir(), vsgi_config_name))
 
 
 vsgi_lib = library('vsgi-' + api_version, vsgi_sources,

--- a/src/vsgi-config.vala.in
+++ b/src/vsgi-config.vala.in
@@ -16,5 +16,5 @@
  */
 
 namespace VSGI.Config {
-	const string MODULE_PATH_FALLBACK = "@MODULE_DIR@";
+	public const string MODULE_PATH_FALLBACK = "@MODULE_DIR@";
 }

--- a/src/vsgi-config.vala.in
+++ b/src/vsgi-config.vala.in
@@ -1,0 +1,20 @@
+/*
+ * This file is part of Valum.
+ *
+ * Valum is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Valum is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Valum.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace VSGI.Config {
+	const string MODULE_PATH_FALLBACK = "@MODULE_DIR@";
+}

--- a/src/vsgi-server-module.vala
+++ b/src/vsgi-server-module.vala
@@ -57,14 +57,20 @@ public class VSGI.ServerModule : TypeModule {
 	}
 
 	construct {
+		string module_file_name = "vsgi-%s".printf (name);
 		// trim the suffix from 'build_path'
-		path = Module.build_path (directory, "vsgi-%s".printf (name))[0:- Module.SUFFIX.length - 1];
+		path = Module.build_path (directory, module_file_name)[0:- Module.SUFFIX.length - 1];
+		File module_path = File.new_for_path (path);
+		if (!module_path.query_exists ()) {
+			path = Module.build_path (Config.MODULE_PATH_FALLBACK, module_file_name)[0:- Module.SUFFIX.length - 1];
+		}
 	}
 
 	public override bool load () {
 		module = Module.open (path, ModuleFlags.BIND_LAZY);
 
 		if (module == null) {
+			module = Path.build_path (Config.MODULE_PATH_FALLBACK, path);
 			critical (Module.error ());
 			return false;
 		}

--- a/src/vsgi-server-module.vala
+++ b/src/vsgi-server-module.vala
@@ -58,10 +58,14 @@ public class VSGI.ServerModule : TypeModule {
 
 	construct {
 		string module_file_name = "vsgi-%s".printf (name);
-		// trim the suffix from 'build_path'
-		path = Module.build_path (directory, module_file_name)[0:- Module.SUFFIX.length - 1];
-		File module_path = File.new_for_path (path);
-		if (!module_path.query_exists ()) {
+		string module_path = Module.build_path (directory, module_file_name);
+		File module_file = File.new_for_path (module_path);
+
+		if (module_file.query_exists ()) {
+			// trim the suffix from 'build_path'
+			path = module_path[0:- Module.SUFFIX.length - 1];
+		} else {
+			// trim the suffix from 'build_path'
 			path = Module.build_path (Config.MODULE_PATH_FALLBACK, module_file_name)[0:- Module.SUFFIX.length - 1];
 		}
 	}

--- a/src/vsgi-server-module.vala
+++ b/src/vsgi-server-module.vala
@@ -70,7 +70,6 @@ public class VSGI.ServerModule : TypeModule {
 		module = Module.open (path, ModuleFlags.BIND_LAZY);
 
 		if (module == null) {
-			module = Path.build_path (Config.MODULE_PATH_FALLBACK, path);
 			critical (Module.error ());
 			return false;
 		}


### PR DESCRIPTION
Fixes https://github.com/valum-framework/valum/issues/224

Instead of relying on rpath, the default module load path is set via a compile-time constant generated by meson's `[configure_file](https://mesonbuild.com/Reference-manual_functions.html#configure_file)` function.
